### PR TITLE
docs: Use correct new lines for optional parameters example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ service:
 ingress:
   enabled: false
   hosts:
-    {{with $subdomain := (ssm "/exists/subdomain" "default=") }}{{ if $subdomain }}
+    {{- with $subdomain := (ssm "/exists/subdomain" "default=") }}{{ if $subdomain }}
     - service.{{$subdomain}}
-    {{ end }}{{ end }}
+    {{- end }}{{- end }}
 
 ```
 


### PR DESCRIPTION
The current example adds 3 new lines (one before and 2 after) each block.