### PR TITLE
fix: make sed command in makefile to be compatible with BSD/macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test: bootstrap
 .PHONY: dist
 dist:
 	mkdir -p $(DIST)
-	sed -i 's/version:.*/version: "'$(VERSION)'"/g' plugin.yaml
+	sed -i.bak 's/version:.*/version: "'$(VERSION)'"/g' plugin.yaml && rm plugin.yaml.bak
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ${HELM_PLUGIN_NAME} -ldflags $(LDFLAGS) ./cmd
 	tar -zcvf $(DIST)/${HELM_PLUGIN_NAME}-linux.tgz ${HELM_PLUGIN_NAME} README.md LICENSE plugin.yaml
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o ${HELM_PLUGIN_NAME} -ldflags $(LDFLAGS) ./cmd

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "ssm"
-version: "1.0.3"
+version: "1.0.10"
 usage: "Inject AWS SSM parameters into Helm values files"
 description: |-
   Inject AWS SSM parameters into Helm values files


### PR DESCRIPTION
the make install command is failing on BSD/OSX because the `sed -i` command requires a suffix that on GNU is optional. For more information about this problem and solution check this [stackoverflow thread](https://stackoverflow.com/a/44864004/933558).