### PR TITLE
add AssumeRoleTokenProvider

### DIFF
--- a/internal/template.go
+++ b/internal/template.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
@@ -115,8 +116,9 @@ func handleOptions(options []string) (map[string]string, error) {
 func newAWSSession(profile string) *session.Session {
 	// Specify profile for config and region for requests
 	session := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-		Profile:           profile,
+		SharedConfigState:       session.SharedConfigEnable,
+		Profile:                 profile,
+		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
 	}))
 	return session
 }


### PR DESCRIPTION
Currently this tooling does not allow for using an aws profile that assumes a role with mfa enabled.

```
$ helm ssm -d -v -p staging -f values.yaml
panic: AssumeRoleTokenProviderNotSetError: assume role with MFA enabled, but AssumeRoleTokenProvider session option not set.
```

[Adding the AssumeRoleTokenProvider](https://aws.amazon.com/blogs/developer/assume-aws-iam-roles-with-mfa-using-the-aws-sdk-for-go/) allows for this functionality 

> After you've updated your shared configuration file, you can update your application code's Sessions to specify how the MFA token code is retrieved from your application's users. If a shared configuration profile specifies a role to assume, and the mfa_serial field is provided, the SDK requires that the AssumeRoleTokenProvider session option is also set. There's no harm in always setting the AssumeRoleTokenProvider session for applications that will always be run by a person. The field is only used if the shared configuration's profile has a role to assume, and then sets the mfa_serial field. Otherwise, the option is ignored.

```
$ helm ssm -d -v -p staging -f values.yaml
Assume Role MFA token code: 833369
service:
ingress:
  enabled: false
  hosts:
    - service.helm-test-tag
```