### PR TITLE
Add support for a global prefix

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,7 @@ import (
 var valueFiles valueFilesList
 var targetDir string
 var profile string
+var prefix string
 var verbose bool
 var dryRun bool
 
@@ -46,6 +47,7 @@ func main() {
 	f.BoolVarP(&dryRun, "dry-run", "d", false, "doesn't replace the file content")
 	f.StringVarP(&targetDir, "target-dir", "o", "", "dir to output content")
 	f.StringVarP(&profile, "profile", "p", "", "aws profile to fetch the ssm parameters")
+	f.StringVarP(&prefix, "prefix", "", "", "prefix to apply by default to parameters")
 
 	cmd.MarkFlagRequired("values")
 
@@ -56,7 +58,7 @@ func main() {
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	funcMap := hssm.GetFuncMap(profile)
+	funcMap := hssm.GetFuncMap(profile, prefix)
 	for _, filePath := range valueFiles {
 		content, err := hssm.ExecuteTemplate(filePath, funcMap, verbose)
 		if err != nil {

--- a/internal/template.go
+++ b/internal/template.go
@@ -113,9 +113,6 @@ func handleOptions(options []string) (map[string]string, error) {
 	if _, exists := opts["required"]; !exists {
 		opts["required"] = "true"
 	}
-	if _, exists := opts["prefix"]; !exists {
-		opts["prefix"] = ""
-	}
 	return opts, nil
 }
 

--- a/internal/template_test.go
+++ b/internal/template_test.go
@@ -63,7 +63,7 @@ func TestFailExecuteTemplate(t *testing.T) {
 
 func TestSsmFunctionExistsInFuncMap(t *testing.T) {
 	t.Logf("\"ssm\" function should exist in function map.")
-	funcMap := GetFuncMap("")
+	funcMap := GetFuncMap("", "")
 	keys := make([]string, len(funcMap))
 	for k := range funcMap {
 		keys = append(keys, k)
@@ -75,7 +75,7 @@ func TestSsmFunctionExistsInFuncMap(t *testing.T) {
 
 func TestSprigFunctionsExistInFuncMap(t *testing.T) {
 	t.Logf("\"quote\" function (from sprig) should exist in function map.")
-	funcMap := GetFuncMap("")
+	funcMap := GetFuncMap("", "")
 	keys := make([]string, len(funcMap))
 	for k := range funcMap {
 		keys = append(keys, k)


### PR DESCRIPTION
This adds the ability to set a "default" prefix globally. The prefix can still be overridden on an individual parameter. 