### PR TITLE
feature: Implement clean option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ $ helm ssm [flags]
 ### Flags
 
 ```sh
-  -d, --dry-run                 does not replace the file content
+  -c, --clean                   clean all template commands from file
+  -d, --dry-run                 doesn't replace the file content
   -h, --help                    help for ssm
   -p, --profile string          aws profile to fetch the ssm parameters
+  -t, --tag-cleaned string      replace cleaned template commands with given string
   -o, --target-dir string       dir to output content
   -f, --values valueFilesList   specify values in a YAML file (can specify multiple) (default [])
   -v, --verbose                 show the computed YAML values file/s

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -48,8 +48,8 @@ func main() {
 	f.BoolVarP(&dryRun, "dry-run", "d", false, "doesn't replace the file content")
 	f.StringVarP(&targetDir, "target-dir", "o", "", "dir to output content")
 	f.StringVarP(&profile, "profile", "p", "", "aws profile to fetch the ssm parameters")
-	f.BoolVarP(&clean, "clean", "c", false, "clean all ssm commands from file")
-	f.StringVarP(&tagCleaned, "tag-cleaned", "t", "", "replace cleaned command with given string")
+	f.BoolVarP(&clean, "clean", "c", false, "clean all template commands from file")
+	f.StringVarP(&tagCleaned, "tag-cleaned", "t", "", "replace cleaned template commands with given string")
 
 	cmd.MarkFlagRequired("values")
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,6 +15,7 @@ var targetDir string
 var profile string
 var verbose bool
 var dryRun bool
+var clean bool
 
 type valueFilesList []string
 
@@ -46,6 +47,7 @@ func main() {
 	f.BoolVarP(&dryRun, "dry-run", "d", false, "doesn't replace the file content")
 	f.StringVarP(&targetDir, "target-dir", "o", "", "dir to output content")
 	f.StringVarP(&profile, "profile", "p", "", "aws profile to fetch the ssm parameters")
+	f.BoolVarP(&clean, "clean", "c", false, "clean all ssm commands from file")
 
 	cmd.MarkFlagRequired("values")
 
@@ -56,7 +58,7 @@ func main() {
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	funcMap := hssm.GetFuncMap(profile)
+	funcMap := hssm.GetFuncMap(profile, clean)
 	for _, filePath := range valueFiles {
 		content, err := hssm.ExecuteTemplate(filePath, funcMap, verbose)
 		if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,7 @@ var profile string
 var verbose bool
 var dryRun bool
 var clean bool
+var tagCleaned string
 
 type valueFilesList []string
 
@@ -48,6 +49,7 @@ func main() {
 	f.StringVarP(&targetDir, "target-dir", "o", "", "dir to output content")
 	f.StringVarP(&profile, "profile", "p", "", "aws profile to fetch the ssm parameters")
 	f.BoolVarP(&clean, "clean", "c", false, "clean all ssm commands from file")
+	f.StringVarP(&tagCleaned, "tag-cleaned", "t", "", "replace cleaned command with given string")
 
 	cmd.MarkFlagRequired("values")
 
@@ -58,7 +60,7 @@ func main() {
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	funcMap := hssm.GetFuncMap(profile, clean)
+	funcMap := hssm.GetFuncMap(profile, clean, tagCleaned)
 	for _, filePath := range valueFiles {
 		content, err := hssm.ExecuteTemplate(filePath, funcMap, verbose)
 		if err != nil {

--- a/internal/template.go
+++ b/internal/template.go
@@ -49,10 +49,10 @@ func ExecuteTemplate(sourceFilePath string, funcMap template.FuncMap, verbose bo
 }
 
 // GetFuncMap builds the relevant function map to helm_ssm
-func GetFuncMap(profile string, clean bool) template.FuncMap {
+func GetFuncMap(profile string, clean bool, tagCleaned string) template.FuncMap {
 
 	cleanFunc := func(...interface{}) (string, error) {
-		return "CLEANED_BY_HELM_SSM", nil
+		return tagCleaned, nil
 	}
 	// Clone the func map because we are adding context-specific functions.
 	var funcMap template.FuncMap = map[string]interface{}{}

--- a/internal/template.go
+++ b/internal/template.go
@@ -49,21 +49,33 @@ func ExecuteTemplate(sourceFilePath string, funcMap template.FuncMap, verbose bo
 }
 
 // GetFuncMap builds the relevant function map to helm_ssm
-func GetFuncMap(profile string) template.FuncMap {
+func GetFuncMap(profile string, clean bool) template.FuncMap {
+
+	cleanFunc := func(...interface{}) (string, error) {
+		return "CLEANED_BY_HELM_SSM", nil
+	}
 	// Clone the func map because we are adding context-specific functions.
 	var funcMap template.FuncMap = map[string]interface{}{}
 	for k, v := range sprig.GenericFuncMap() {
-		funcMap[k] = v
+		if clean {
+			funcMap[k] = cleanFunc
+		} else {
+			funcMap[k] = v
+		}
 	}
 
 	awsSession := newAWSSession(profile)
-	funcMap["ssm"] = func(ssmPath string, options ...string) (string, error) {
-		optStr, err := resolveSSMParameter(awsSession, ssmPath, options)
-		str := ""
-		if optStr != nil {
-			str = *optStr
+	if clean {
+		funcMap["ssm"] = cleanFunc
+	} else {
+		funcMap["ssm"] = func(ssmPath string, options ...string) (string, error) {
+			optStr, err := resolveSSMParameter(awsSession, ssmPath, options)
+			str := ""
+			if optStr != nil {
+				str = *optStr
+			}
+			return str, err
 		}
-		return str, err
 	}
 	return funcMap
 }

--- a/internal/template_test.go
+++ b/internal/template_test.go
@@ -28,7 +28,25 @@ func TestExecuteTemplate(t *testing.T) {
 	}
 	defer syscall.Unlink(templateFilePath)
 	ioutil.WriteFile(templateFilePath, []byte(templateContent), 0644)
-	content, err := ExecuteTemplate(templateFilePath, template.FuncMap{}, false)
+	content, _ := ExecuteTemplate(templateFilePath, template.FuncMap{}, false)
+	if content != expectedOutput {
+		t.Errorf("Expected content \"%s\". Got \"%s\"", expectedOutput, content)
+	}
+}
+
+func TestCleanTemplate(t *testing.T) {
+	templateContent := "example: {{ssm \"foo\" | quote | indent 8}}"
+	expectedOutput := "example: CLEANED_BY_HELM_SSM"
+	t.Logf("Template with content: %s , should out put a file with content: %s", templateContent, expectedOutput)
+
+	templateFilePath, err := createTempFile()
+	if err != nil {
+		panic(err)
+	}
+	defer syscall.Unlink(templateFilePath)
+	ioutil.WriteFile(templateFilePath, []byte(templateContent), 0644)
+	cleanFuncMap := GetFuncMap("DUMMY", true)
+	content, _ := ExecuteTemplate(templateFilePath, cleanFuncMap, false)
 	if content != expectedOutput {
 		t.Errorf("Expected content \"%s\". Got \"%s\"", expectedOutput, content)
 	}
@@ -63,7 +81,7 @@ func TestFailExecuteTemplate(t *testing.T) {
 
 func TestSsmFunctionExistsInFuncMap(t *testing.T) {
 	t.Logf("\"ssm\" function should exist in function map.")
-	funcMap := GetFuncMap("")
+	funcMap := GetFuncMap("", false)
 	keys := make([]string, len(funcMap))
 	for k := range funcMap {
 		keys = append(keys, k)
@@ -75,7 +93,7 @@ func TestSsmFunctionExistsInFuncMap(t *testing.T) {
 
 func TestSprigFunctionsExistInFuncMap(t *testing.T) {
 	t.Logf("\"quote\" function (from sprig) should exist in function map.")
-	funcMap := GetFuncMap("")
+	funcMap := GetFuncMap("", false)
 	keys := make([]string, len(funcMap))
 	for k := range funcMap {
 		keys = append(keys, k)


### PR DESCRIPTION
Implements an option, `helm ssm -c`, that instructs helm ssm to clean all templating from the file.