### PR TITLE
fix: Remove missing hooks

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,6 +6,3 @@ description: |-
 ignoreFlags: false
 useTunnel: false
 command: "$HELM_PLUGIN_DIR/helm-ssm"
-hooks:
-  install: "$HELM_PLUGIN_DIR/install-binary.sh"
-  update: "$HELM_PLUGIN_DIR/install-binary.sh"


### PR DESCRIPTION
Reference to these missing hooks causes helm to refuse to install the plugin.